### PR TITLE
Fix bad Errorf formatting reported by go 1.11.5.

### DIFF
--- a/gpt.go
+++ b/gpt.go
@@ -473,7 +473,7 @@ func stringToGuid(guid string) (res [16]byte, err error) {
 			case 'F', 'f':
 				bt |= 15 << shift
 			default:
-				err = fmt.Errorf("BAD guid char: ", i+pos, ch)
+				err = fmt.Errorf("BAD guid char at pos %d: '%c'", i+pos, ch)
 				return
 			}
 		}


### PR DESCRIPTION
Simple fix to bad Errorf() usage, fixes:
  Errorf call has arguments but no formatting directive.