### PR TITLE
Add NewTable method for creating a new Table structure.

### DIFF
--- a/gpt.go
+++ b/gpt.go
@@ -433,7 +433,14 @@ func NewTable(diskSize uint64, args *NewTableArgs) Table {
 		args.DiskGuid = Guid(uuid.New())
 	}
 
+	ptStartLBA := uint64(2)
 	numParts := 128
+	partitionsTableSize := uint64(standardPartitionEntrySize) * uint64(numParts)
+	partitionSizeInSector := partitionsTableSize / uint64(args.SectorSize)
+	if partitionsTableSize%uint64(args.SectorSize) != 0 {
+		partitionSizeInSector++
+	}
+
 	return Table{
 		SectorSize: args.SectorSize,
 		Header: Header{
@@ -444,10 +451,10 @@ func NewTable(diskSize uint64, args *NewTableArgs) Table {
 			Reserved:                0,
 			HeaderStartLBA:          1,
 			HeaderCopyStartLBA:      0,
-			FirstUsableLBA:          34,
+			FirstUsableLBA:          ptStartLBA + partitionSizeInSector,
 			LastUsableLBA:           0,
 			DiskGUID:                args.DiskGuid,
-			PartitionsTableStartLBA: 2,
+			PartitionsTableStartLBA: ptStartLBA,
 			PartitionsArrLen:        uint32(numParts),
 			PartitionEntrySize:      uint32(standardPartitionEntrySize),
 			PartitionsCRC:           0x0,

--- a/gpt_test.go
+++ b/gpt_test.go
@@ -194,6 +194,55 @@ func TestReadWriteTable(t *testing.T) {
 	}
 }
 
+func TestNewTable(t *testing.T) {
+	guid := Guid{0xc5, 0x7f, 0x7e, 0x46, 0x36, 0x2b, 0x4e, 0x60, 0x9a, 0xa9, 0xa6, 0xe9, 0xdd, 0x85, 0x94, 0xa6}
+	ssize := 512
+	diskSize := uint64(250000384) // round 512 sectors closest to 250gb
+	numSectors := diskSize / uint64(ssize)
+	table := NewTable(uint64(ssize), diskSize, guid)
+
+	h := table.Header
+	if h.DiskGUID != guid {
+		t.Errorf("found DiskGUID %v != %v", guid, h.DiskGUID)
+	}
+
+	if len(h.TrailingBytes) != ssize-standardHeaderSize {
+		t.Errorf("Found TralingBytes len %d expected %d", len(h.TrailingBytes), ssize-standardHeaderSize)
+	}
+
+	if h.CRC != h.calcCRC() {
+		t.Error("CRC")
+	}
+	if h.Reserved != 0 {
+		t.Error("Reserved")
+	}
+	if h.HeaderStartLBA != 1 {
+		t.Error("CurrentLBA", h.HeaderStartLBA)
+	}
+	if h.HeaderCopyStartLBA != numSectors-1 {
+		t.Error("Other LBA", h.HeaderCopyStartLBA, numSectors-1)
+	}
+	if h.FirstUsableLBA != 34 {
+		t.Error("FirstUsable: ", h.FirstUsableLBA)
+	}
+	if h.LastUsableLBA != numSectors-34 {
+		t.Errorf("LastUsable: expected %d found %d", numSectors-34, h.LastUsableLBA)
+	}
+	if h.PartitionsTableStartLBA != 2 {
+		t.Error("Start partition entries: ", h.PartitionsTableStartLBA)
+	}
+	if h.PartitionsArrLen != 128 {
+		t.Error("Partition arr len", h.PartitionsArrLen)
+	}
+	if h.PartitionEntrySize != 128 {
+		t.Error("Partition entry size:", h.PartitionEntrySize)
+	}
+	if h.PartitionsCRC != 0 {
+		t.Error("Partitions CRC", h.PartitionsCRC)
+	}
+
+}
+
 func TestTableCreateOtherSide(t *testing.T) {
 	buf := make([]byte, 512+512+32*512)
 	copy(buf[512:], GPT_TEST_HEADER)

--- a/gpt_test.go
+++ b/gpt_test.go
@@ -199,7 +199,7 @@ func TestNewTable(t *testing.T) {
 	ssize := 512
 	diskSize := uint64(250000384) // round 512 sectors closest to 250gb
 	numSectors := diskSize / uint64(ssize)
-	table := NewTable(uint64(ssize), diskSize, guid)
+	table := NewTable(diskSize, &NewTableArgs{uint64(ssize), guid})
 
 	h := table.Header
 	if h.DiskGUID != guid {


### PR DESCRIPTION
There was previously no easy way to create an entirely new Table.
The assumption was mostly that some other software had written
a GPT table and this software would read it.

NewTable allows the user to create a new gpt.Table that can be
written to disk with with gpt.Table.Write().